### PR TITLE
Add some unit tests and run perf tests regardless of input

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -30,6 +30,7 @@ jobs:
         uses: actions-rs/tarpaulin@v0.1
         with:
           version: '0.18.0'
+          args: '--exclude-files src/bin/*'
 
       - name: 🆙 Upload to codecov.io
         uses: codecov/codecov-action@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,4 +37,4 @@ jobs:
         name: 🔎 Run unit tests
         with:
           command: test
-          args: --release
+          args: --release --features measurements

--- a/src/bin/batch_error_eval.rs
+++ b/src/bin/batch_error_eval.rs
@@ -272,21 +272,13 @@ fn rank(input: InputDataPoint, fbas_type: FbasType, qi_check: bool) -> ErrorData
         "Starting 10^8 approximation run {} for FBAS of size {}.",
         input.run, size
     );
-    let approx_power_indices_10_pow_8 = if input.top_tier_size <= 23 {
-        rank_nodes(
-            &fbas,
-            RankingAlg::PowerIndexApprox(10usize.pow(8)),
-            qi_check,
-        )
-    } else {
-        Vec::default()
-    };
+    let approx_power_indices_10_pow_8 = rank_nodes(
+        &fbas,
+        RankingAlg::PowerIndexApprox(10usize.pow(8)),
+        qi_check,
+    );
     let (mean_abs_error_10_pow_8, median_abs_error_10_pow_8, mean_abs_percentage_error_10_pow_8) =
-        if input.top_tier_size <= 23 {
-            mean_med_pctg_errors(&approx_power_indices_10_pow_8, &exact_power_index)
-        } else {
-            (f64::NAN, f64::NAN, f64::NAN)
-        };
+        mean_med_pctg_errors(&approx_power_indices_10_pow_8, &exact_power_index);
     info!(
         "Completed 10^8 Approximation run {} for FBAS of size {}.",
         input.run, size

--- a/src/sim/io.rs
+++ b/src/sim/io.rs
@@ -103,3 +103,30 @@ pub fn write_csv_via_writer(
     }
     Ok(())
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::Path;
+
+    #[test]
+    fn read_from_nonexistent_file_doesnt_panic() {
+        let file_path = Path::new("");
+        let actual = read_csv_from_file(file_path);
+        assert!(actual.is_err());
+    }
+
+    #[test]
+    fn write_to_nonexistent_file_doesnt_panic() {
+        let file_path = Path::new("");
+        let mock_data = PerfDataPoint {
+            top_tier_size: usize::default(),
+            run: usize::default(),
+            duration: f64::default(),
+            duration_after_mq: f64::default(),
+        };
+
+        let actual = write_csv_to_file(vec![mock_data], file_path);
+        assert!(actual.is_err());
+    }
+}

--- a/tests/batch_cli.rs
+++ b/tests/batch_cli.rs
@@ -2,12 +2,15 @@ use assert_cmd::Command;
 use predicates::prelude::*;
 
 #[test]
-#[ignore]
-// ignore for now because binary only available when feature is active
-// causes coverage test to fail
-fn valid_batch_perf_experiments_command() -> Result<(), Box<dyn std::error::Error>> {
-    let mut cmd = Command::cargo_bin("batch_performance_eval")?;
-    cmd.arg("-r").arg("1").arg("-m").arg("1").arg("stellar");
+#[cfg_attr(not(feature = "measurements"), ignore)]
+fn valid_batch_perf_experiments() -> Result<(), Box<dyn std::error::Error>> {
+    let mut cmd = Command::cargo_bin("performance_tests")?;
+    cmd.arg("-r")
+        .arg("1")
+        .arg("-m")
+        .arg("1")
+        .arg("stellar")
+        .arg("power-index-enum");
     cmd.assert().success().stdout(predicate::str::contains(
         "Starting performance measurements for Stellar like FBAS with upto 1 nodes.\n Performing 1 iterations per FBAS.",
     ));
@@ -15,12 +18,10 @@ fn valid_batch_perf_experiments_command() -> Result<(), Box<dyn std::error::Erro
 }
 
 #[test]
-#[ignore]
+#[cfg_attr(not(feature = "measurements"), ignore)]
 fn no_fbas_type_in_command() -> Result<(), Box<dyn std::error::Error>> {
-    let mut cmd = Command::cargo_bin("batch_error_eval")?;
-    cmd.arg("--features")
-        .arg("measurements")
-        .arg("-m")
+    let mut cmd = Command::cargo_bin("approximation_tests")?;
+    cmd.arg("-m")
         .arg("10")
         .arg("-j")
         .arg("4")


### PR DESCRIPTION
- All perf. tests are now run for 10^8 for all inputs
- Adds some more tests for opt features
- which are then tested in CI but not included in the coverage report 